### PR TITLE
Added error reporting to main.cpp, added test for error reporting

### DIFF
--- a/grammars/Makefile
+++ b/grammars/Makefile
@@ -44,7 +44,10 @@ clean:
 	-rm anbncn anbncn.cpp 
 	-rm calc calc.cpp
 
-test: egg abc anbncn calc
+reporting:
+	../egg -i errorcalc.egg 2>&1 | grep -i -q "line 7"
+
+test: egg abc anbncn calc reporting
 	@echo
 	./abc < tests/abc.in.txt > tests/abc.test.txt
 	diff tests/abc.out.txt tests/abc.test.txt
@@ -55,3 +58,5 @@ test: egg abc anbncn calc
 	rm tests/*.test.txt
 	@echo
 	@echo TESTS PASSED
+
+.PHONY: reporting test clean

--- a/grammars/errorcalc.egg
+++ b/grammars/errorcalc.egg
@@ -1,0 +1,8 @@
+sum : int = prod : i { psVal = i; } (
+            '+' prod : i { psVal += i; }
+            | '-' prod : i { psVal -= i; } )*
+prod : int = elem : i { psVal = i; } (
+             '*' elem : i { psVal *= i; }
+             | '/' elem : i { psVal /= i; } )*
+elem %% int = '(' sum : i ')' { psVal = i; }
+              | < [0-9]+ > { psVal = atoi(psCapture.c_str()); }

--- a/main.cpp
+++ b/main.cpp
@@ -20,6 +20,7 @@
  * THE SOFTWARE.
  */
 
+#include <cmath>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -261,9 +262,22 @@ int main(int argc, char** argv) {
 		}
 		
 	} else {
-		std::cerr << "PARSE FAILURE" << std::endl;
+		int64_t maxPos=ps.maxRead();
+		int64_t startPos; for (startPos=maxPos-1;startPos>0&&ps[startPos]!='\n';--startPos); ++startPos;
+		int64_t endPos; for (endPos=maxPos;ps[endPos]!='\n'&&ps[endPos]!='\0';++endPos);
+		int64_t lineCount=1;
+		try {
+			for(int64_t pos=startPos;pos>0;--pos) lineCount+=(ps[pos]=='\n');
+		} catch(parse::forgotten_state_error& e) {
+			lineCount += e.newlines;
+		}
+		int64_t errPos=maxPos-startPos;
+
+		std::cerr << "Parse failure " << maxPos << " bytes into the input:" << std::endl;
+		std::cerr << "line " << lineCount << ":   " << ps.string(startPos,endPos-startPos) << std::endl;
+		std::cerr << std::string(5+ceil(log10(lineCount)+4),' ') << std::string(maxPos-startPos-1, ' ') << "^-- error, column " << errPos << std::endl;
+		return 1;
 	}
 
 	return 0;
 } /* main() */
-


### PR DESCRIPTION
I've added basic error reporting to main.cpp. This should ideally be done in a different, rule based way but knowing at which point the parser stopped consuming input is usually incredible helpful. Since writing big-ish grammers for egg becomes a pain without any error info, I've added this reporting style for now. If you are interested I'd be happy if we could get this or a similar feature into your master branch.
